### PR TITLE
fix: autoSession required arg & biomejs linter warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,105 @@
 # Croquet 🦩
+
 [![NPM Version](https://img.shields.io/npm/v/%40croquet%2Fcroquet)](http://npmjs.com/package/@croquet/croquet)
 [![NPM Dev](https://img.shields.io/npm/v/%40croquet%2Fcroquet/dev?color=%23C33)](https://www.npmjs.com/package/@croquet/croquet?activeTab=versions)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE.txt)
 
-*Croquet lets you build real-time multiuser apps without writing server-side code. Unlike traditional client/server architectures, the multiplayer code is executed on each client in a synchronized virtual machine, rather than on a server.*
+**Croquet enables you to build real-time multiuser applications without writing server-side code.** Unlike traditional client/server architectures, the multiplayer logic executes on each client in a synchronized virtual machine, rather than on a centralized server.
 
-Croquet is available as a JavaScript library that synchronizes Croquet apps using Multisynq's global DePIN network. Additionally, the reflector server keeping VMs in sync is available as a node.js package.
+Croquet is available as a JavaScript library that synchronizes applications using [Multisynq's global DePIN network](https://multisynq.io). Additionally, the reflector server that keeps virtual machines in sync is available as a Node.js package for self-hosting.
+
+## Quick Start
+
+Get started with Croquet in minutes:
+
+1. **Get an API key**: Sign up at [multisynq.io/coder](https://multisynq.io/coder) for a free API key
+2. **Install the library**: `npm install @croquet/croquet`
+3. **Build your first app**: Follow our [quick start guide](https://multisynq.io/docs/croquet/)
+
+## Key Features
+
+- 🚀 **No server code required** - Deploy as static websites
+- 🔄 **Real-time synchronization** - Automatic state sync across all clients
+- 🌐 **Global infrastructure** - Powered by Multisynq's decentralized network
+- 🎯 **Framework agnostic** - Works with any UI framework
+- 🔒 **End-to-end encrypted** - Session data is never decrypted on servers
+- 📦 **Self-hostable** - Run your own reflector servers if needed
 
 ## License
 
 Croquet is licensed under [Apache-2.0](LICENSE.txt).
 
-## Testing
+## Development & Testing
 
-Some of the examples in `apps/` require to build a local version of Croquet, which you can do by
+### Building the Library
 
-    cd packages/croquet
-    ./build.sh
+Some examples in `apps/` require a local build of Croquet:
 
-Then the apps should work directly from their source in `apps/`.
+```bash
+cd packages/croquet
+./build.sh
+```
 
-Alternatively, run `build.sh` in this root folder, which will both build the Croquet library and build the `apps/` into a `_site/` folder. This also gets run via a GitHub action  which creates the GitHub Pages site.
+### Building Everything
 
-The examples in `apps/` use a place holder Multisynq API key that is only valid for testing on the local network and the Croquet GitHub Pages site. You can get your own key on the [Multisynq](https://multisynq.io/coder) website. Alternatively, check out Croquet-in-a-Box below.
+To build both the library and all examples:
 
-## Repo Layout
+```bash
+./build.sh
+```
 
-* `apps`: various examples and tests
+This creates a `_site/` folder with all built applications and is used by our GitHub Actions for the GitHub Pages site.
 
-* `docs`: JSDoc sources
+### API Keys for Testing
 
-* `packages`:
-    * `croquet`: the client-side package
-    * `reflector`: the node.js server package
+The examples in `apps/` use a placeholder Multisynq API key that is only valid for testing on the local network and the Croquet GitHub Pages site. You can get your own key on the [Multisynq](https://multisynq.io/coder) website. Alternatively, check out Croquet-in-a-Box below.
 
-* `server`:
-    * `croquet-in-a-box`: via Docker Compose, an all-in-one server for local development, containing
-        * a reflector
-        * a web server
-        * and a file server
+## Repository Structure
+
+```
+croquet/
+├── apps/                    # Various examples and tests
+├── docs/                    # Documentation source files (JSDoc)
+├── packages/
+│   ├── croquet/            # Main client-side Croquet library
+│   └── reflector/          # Node.js reflector server package
+├── server/
+    └── croquet-in-a-box/   # Docker-based local development server
+```
+
+### Key Directories
+
+- **`apps/`** - Various Croquet applications including `hello/`, `chat/`, `video/`, `threejs/`, `youtube/`, and others
+- **`docs/`** - JSDoc source files for generating documentation
+- **`packages/croquet/`** - The main client-side JavaScript library
+- **`packages/reflector/`** - Self-hostable reflector server implementation
+- **`server/croquet-in-a-box/`** - All-in-one Docker setup containing:
+  - Reflector server
+  - Web server
+  - File server
+
+## Croquet-in-a-Box
+
+For local development and testing, Croquet-in-a-Box provides a complete local environment:
+
+```bash
+cd server/croquet-in-a-box
+./croquet-in-a-box.sh
+```
+
+Then visit [http://localhost:8888/](http://localhost:8888/) to try the examples locally.
+
+## Resources
+
+- 📚 **Documentation**: [multisynq.io/docs/croquet](https://multisynq.io/docs/croquet)
+- 🎮 **Examples**: [croquet.io/examples](https://croquet.io/examples)
+- 🌐 **Website**: [croquet.io](https://croquet.io)
+- 💬 **Community**: [Discord](https://discord.gg/croquet)
+
+## Contributing
+
+We welcome contributions! Please see our [contribution guidelines](CONTRIBUTING.md) for more information.
+
+---
+
+Built with ❤️ by the Croquet team

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,19 +1,75 @@
-# Croquet Docs
+# Croquet Documentation
 
-The docs are deployed at https://croquet.io/docs/croquet and https://multisynq.io/docs/croquet.
+This directory contains the source files for Croquet's comprehensive documentation.
 
-## Building
-The doc generator and theme are in the `croquet-docs` repo: https://github.com/croquet/croquet-docs/
+## 📖 Live Documentation
 
-It expects `croquet` to be checked out next to `croquet-docs`.
+The documentation is deployed and accessible at:
+- **Primary**: [multisynq.io/docs/croquet](https://multisynq.io/docs/croquet)
+- **Alternative**: [croquet.io/docs/croquet](https://croquet.io/docs/croquet)
 
-    ├── croquet
-    │   └── docs        (this directory)
-    │
-    └── croquet-docs
-        └── croquet
+## 🏗️ Building Documentation Locally
 
-If that's in place, you can build the croquet docs using `npm run build` or `npm run watch` in the `croquet-docs/croquet` directory.
+### Prerequisites
 
-The doc generator uses [JSDoc](https://jsdoc.app) to build the class documentation from structured comments in the source code (see `packages/croquet/teatime/src`, in particular `index.js`, `model.js`, `view.js`, `session.js`), as well as tutorials from markdown files in this directory.
+The documentation generator and theme are maintained in a separate repository: [croquet-docs](https://github.com/croquet/croquet-docs/).
+
+### Setup
+
+You need both repositories checked out as siblings:
+
+```
+your-workspace/
+├── croquet/                # This repository
+│   └── docs/              # This directory
+└── croquet-docs/          # Documentation generator repo
+    └── croquet/
+```
+
+### Building
+
+Once the directory structure is in place:
+
+```bash
+cd croquet-docs/croquet
+npm run build        # One-time build
+npm run watch        # Continuous build with file watching
+```
+
+## 📝 Documentation Structure
+
+The documentation system combines multiple sources:
+
+### API Documentation
+Generated from **JSDoc comments** in the source code:
+- `packages/croquet/teatime/src/index.js`
+- `packages/croquet/teatime/src/model.js`
+- `packages/croquet/teatime/src/view.js`
+- `packages/croquet/teatime/src/session.js`
+
+### Tutorials
+Written as **Markdown files** in this directory (`docs/`), covering:
+- Getting started guides
+- Step-by-step tutorials
+- Advanced concepts
+- Best practices
+
+### Technology
+
+The documentation is built using:
+- **[JSDoc](https://jsdoc.app)** - API documentation generator
+- **Custom theme** - Optimized for Croquet's needs
+- **Markdown processing** - For tutorials and guides
+
+## 🤝 Contributing to Documentation
+
+When contributing to documentation:
+
+1. **API docs**: Update JSDoc comments in the source code
+2. **Tutorials**: Edit or add Markdown files in this directory
+3. **Build and test**: Use the build process above to verify changes
+
+---
+
+For questions about documentation, please reach out through our [community channels](https://discord.gg/croquet).
 

--- a/packages/croquet/README.md
+++ b/packages/croquet/README.md
@@ -1,87 +1,124 @@
 # Croquet
 
-*Croquet lets you build real-time multiuser apps without writing server-side code. Unlike traditional client/server architectures, the multiplayer code is executed on each client in a synchronized virtual machine, rather than on a server. Croquet is available as a JavaScript library that synchronizes Croquet apps using Multisynq's global DePIN network.*
+**Croquet enables you to build real-time multiuser applications without writing server-side code.** Unlike traditional client/server architectures, the multiplayer logic executes on each client in a synchronized virtual machine, rather than on a centralized server.
 
-* can be hosted as a **static website**
-* **no server-side** code needed
-* **no networking** code needed
-* independent of UI framework
+*Croquet is available as a JavaScript library that synchronizes applications using Multisynq's global DePIN network.*
 
-## Getting Started
+## ✨ Key Benefits
 
-Get a free API key from [multisynq.io](https://multisynq.io/coder)
-_(you can run your own server too but by default the client uses the global Multisynq network)._
+- 🚀 **Deploy as static websites** - No server infrastructure needed
+- 🔧 **No server-side code** - Focus purely on your application logic  
+- 🌐 **No networking code** - Automatic synchronization handled for you
+- 🎯 **Framework independent** - Works with React, Vue, vanilla JS, and more
 
-    npm i @croquet/croquet
+## 🚀 Getting Started
 
-You can also use the Croquet pre-bundled files, e.g. via a script tag
+### 1. Get Your API Key
+Get a free API key from [multisynq.io](https://multisynq.io/coder)  
+*(You can also run your own server, but the global Multisynq network is used by default)*
 
-    <script src="https://cdn.jsdelivr.net/npm/@croquet/croquet@2.0.0/pub/croquet.min.js"></script>
+### 2. Install Croquet
 
-or via direct import as a module
+**Via npm:**
+```bash
+npm install @croquet/croquet
+```
 
-    import * as Croquet from "https://cdn.jsdelivr.net/npm/@croquet/croquet@2.0.0/pub/croquet.esm.js";
+**Via CDN (pre-bundled):**
+```html
+<script src="https://cdn.jsdelivr.net/npm/@croquet/croquet@2.0.0/pub/croquet.min.js"></script>
+```
 
-Structure your app into a synchronized part (subclassed from `Croquet.Model`) and a local part interacting with it (subclassed from `Croquet.View`). Uses `Croquet.Session.join()` with your API key to join a session.
+**Via ES modules:**
+```javascript
+import * as Croquet from "https://cdn.jsdelivr.net/npm/@croquet/croquet@2.0.0/pub/croquet.esm.js";
+```
 
-That's it. No deployment of anything except your HTML+JS.
+### 3. Structure Your Application
 
-Follow the documentation at [multisynq.io/docs](https://multisynq.io/docs) and the example apps in the [Croquet GitHub repo](http://github.com/croquet/croquet).
+Organize your app into two parts:
+- **Synchronized part**: Subclass `Croquet.Model` - shared state and logic
+- **Local part**: Subclass `Croquet.View` - user interface and local interactions
 
-## The Prime Directive
+### 4. Join a Session
 
-*Your Croquet Model must be completely self-contained.*
+Use `Croquet.Session.join()` with your API key to connect users.
 
-The model must only interact with the outside world via subscriptions to user input events that are published by a view. Everything else needs to be 100% deterministic. The model must not read any state from global variables, and the view must not modify model state directly (although it is allowed to read from it).
+**That's it!** No server deployment needed - just HTML and JavaScript.
 
-Besides being deterministic, the model must be serializable – it needs to store state in an object-oriented style. That means in particular that the model cannot store functions, which JavaScript does not allow to be introspected for serialization. That also means you cannot use async code in the model. On the view side outside the model you're free to use any style of programming you want.
+## 📚 Learn More
 
-## Servers and networking
+- **Documentation**: [multisynq.io/docs](https://multisynq.io/docs)
+- **Examples**: [Croquet GitHub repo](http://github.com/croquet/croquet)
 
-By default Croquet runs on the [Multisynq DePIN network](https://multisynq.io) which automatically selects a server close to the first connecting user in a session. Alternatively, you can [run your own reflector](https://github.com/croquet/croquet/tree/main/packages/reflector), but be aware you won't get the benefits of a global deployment then.
+## 🎯 The Prime Directive
 
-All application code and data is only processed on the clients. All network communication and external data storage is end-to-end encrypted by the random session password – since the server does not process application data there is no need for it to be decrypted on the server. This makes Croquet one of the most private real-time multiplayer solutions available.
+**Your Croquet Model must be completely self-contained.**
 
-## Change Log
+### Model Requirements
 
-These are user-facing changes adhering to the [keep-a-changelog](https://keepachangelog.com/) format. For detailed internal changes see [CHANGELOG](./CHANGELOG.md).
+- ✅ **Deterministic**: Must produce identical results on all clients
+- ✅ **Serializable**: Store state in object-oriented style (no functions)
+- ✅ **Event-driven**: Interact with outside world only via view-published events
+- ❌ **No global state**: Cannot read from global variables
+- ❌ **No async code**: Cannot use Promises, async/await, setTimeout, etc.
+
+### View Flexibility
+
+The view layer has no restrictions - use any programming style, framework, or async patterns you prefer.
+
+### Why These Rules?
+
+These constraints ensure that all clients maintain identical state, enabling Croquet's unique architecture where the "server" logic runs identically on every client.
+
+## 🌐 Infrastructure & Security
+
+### Global Network
+By default, Croquet runs on the [Multisynq DePIN network](https://multisynq.io), which automatically selects a server close to the first user in each session for optimal performance.
+
+### Self-Hosting
+You can [run your own reflector](https://github.com/croquet/croquet/tree/main/packages/reflector), though you won't benefit from global deployment.
+
+### Privacy & Security
+- **End-to-end encryption**: All communication encrypted by random session password
+- **Zero server processing**: Application code and data only processed on clients  
+- **Server-blind**: Servers never decrypt application data
+- **Maximum privacy**: One of the most private real-time multiplayer solutions available
+
+## 📋 Change Log
+
+*Following [keep-a-changelog](https://keepachangelog.com/) format. For detailed internal changes see [CHANGELOG](./CHANGELOG.md).*
 
 ### [2.0] - 2025-04-08
 
-This is the first release licensed under Apache-2.0.
+**First Apache-2.0 licensed release**
 
-#### Added
-
+#### ✨ Added
 - Support for Multisynq DePIN network (API key at [multisynq.io](https://multisynq.io/coder))
-- add static `Model.isExecuting()` check
-- add `Model.createQFunc()` to allow functions in snapshots
-- add generic subscriptions (scope and/or event are `"*"`)
-- add `activeSubscription()` to access scope, event, and source of currently executing event
-- support snapshotting of static properties
-- add `App.randomSession()` and `App.randomPassword()`
-- `Session.join()` now supports `viewData` property that will be passed to `view-join` event
+- `Model.isExecuting()` static check
+- `Model.createQFunc()` for serializable functions in snapshots
+- Generic subscriptions (scope and/or event as `"*"`)
+- `activeSubscription()` to access current event context (scope, event, source)
+- Static property snapshotting support
+- `App.randomSession()` and `App.randomPassword()` utilities
+- `viewData` property support in `Session.join()` (passed to `view-join` event)
 
 ### [1.1] - 2024-03-20
 
-#### Added
-
+#### ✨ Added
 - `BigInt` snapshotting support
-- `Model.cancelFuture()` allows to stop future message evaluation
-- `Model.evaluate()` to evaluate some code with Model semantics (e.g. to initialize constants)
-- `View.session` makes the session object returned from `Session.join()` available to views
-- `Session.join()` now supports a `viewOptions` property
-- `Model.unsubscribe()` and `View.unsubscribe()` can take a `handler` argument
-- `"write"` debug flag detects accidental writes into model state
-- `"offline"` debug flag lets you run without a network connection (single-user)
-handler arg,
-- Node.js support for running a client on Node
+- `Model.cancelFuture()` to stop scheduled future messages
+- `Model.evaluate()` for code evaluation with Model semantics
+- `View.session` property providing access to session object
+- `viewOptions` property support in `Session.join()`
+- Optional `handler` argument for `Model.unsubscribe()` and `View.unsubscribe()`
+- Debug flags: `"write"` (detects model state mutations), `"offline"` (single-user mode)
+- Node.js client support
 
-#### Fixed
+#### 🐛 Fixed
+- Shared buffer snapshotting in Typed Arrays
+- Circular reference deserialization in Set and Map
 
-- fixed snapshotting of shared buffers in Typed Arrays
-- fixed deserialization of circular Set and Map refs
+### [1.0] - 2021-08-23
 
-
-### [1.0] - 2021-08-23                                                                             |
-
-Public release
+**Initial public release**

--- a/packages/croquet/types.d.ts
+++ b/packages/croquet/types.d.ts
@@ -2,20 +2,20 @@ declare module "@croquet/croquet" {
 
     export type ClassId = string;
 
-    export interface Class<T> {
-        new (...args: never[]): T;
+    export interface Class<T> extends Function {
+        new (...args: any[]): T;
     }
 
     export type InstanceSerializer<T, IS> = {
         cls: Class<T>;
         write: (value: T) => IS;
         read: (state: IS) => T;
-    };
+    }
 
     export type StaticSerializer<S> = {
         writeStatic: () => S;
         readStatic: (state: S) => void;
-    };
+    }
 
     export type InstAndStaticSerializer<T, IS, S> = {
         cls: Class<T>;
@@ -23,12 +23,9 @@ declare module "@croquet/croquet" {
         read: (state: IS) => T;
         writeStatic: () => S;
         readStatic: (state: S) => void;
-    };
+    }
 
-    export type Serializer =
-        | InstanceSerializer<object, object>
-        | StaticSerializer<object>
-        | InstAndStaticSerializer<object, object, object>;
+    export type Serializer = InstanceSerializer<any, any> | StaticSerializer<any> | InstAndStaticSerializer<any, any, any>;
 
     export type SubscriptionHandler<T> = ((e: T) => void) | string;
 
@@ -47,17 +44,15 @@ declare module "@croquet/croquet" {
         unsubscribeAll(): void;
     }
 
-    export type FutureHandler<T extends readonly unknown[]> =
-        | ((...args: T) => void)
-        | string;
+    export type FutureHandler<T extends any[]> = ((...args: T) => void) | string;
 
-    export type QFuncEnv = Record<string, object>;
+    export type QFuncEnv = Record<string, any>;
 
     export type EventType = {
         scope: string;
         event: string;
         source: "model" | "view";
-    };
+    }
 
     /**
      * Models are synchronized objects in Croquet.
@@ -92,7 +87,7 @@ declare module "@croquet/croquet" {
      * @hideconstructor
      * @public
      */
-    export class Model extends PubSubParticipant<Record<string, never>> {
+    export class Model extends PubSubParticipant<{}> {
         id: string;
 
         /**
@@ -117,10 +112,7 @@ declare module "@croquet/croquet" {
          * @param options - option object to be passed to [init()]{@link Model#init}.
          *     There are no system-defined options as of now, you're free to define your own.
          */
-        static create<T extends typeof Model>(
-            this: T,
-            options?: Record<string, unknown>,
-        ): InstanceType<T>;
+        static create<T extends typeof Model>(this: T, options?: any): InstanceType<T>;
 
         /**
          * __Registers this model subclass with Croquet__
@@ -141,7 +133,7 @@ declare module "@croquet/croquet" {
          * @param classId Id for this model class. Must be unique. If you use the same class name in two files, use e.g. `"file1/MyModel"` and `"file2/MyModel"`.
          * @public
          */
-        static register(classId: ClassId): void;
+        static register(classId:ClassId): void;
 
         /** Static version of [wellKnownModel()]{@link Model#wellKnownModel} for currently executing model.
          *
@@ -221,7 +213,8 @@ declare module "@croquet/croquet" {
          * ```
          * @public
          */
-        static types(): Record<ClassId, Class<object> | Serializer>;
+        static types(): Record<ClassId, Class<any> | Serializer>;
+
 
         /** Find classes inside an external library
          *
@@ -247,10 +240,7 @@ declare module "@croquet/croquet" {
          * @param {String} prefix - a prefix to add to the class names
          * @since 2.0
          */
-        static gatherClassTypes<T extends Record<string, unknown>>(
-            dummyObject: T,
-            prefix: string,
-        ): Record<ClassId, Class<object>>;
+        static gatherClassTypes<T extends Object>(dummyObject: T, prefix: string): Record<ClassId, Class<any>>;
 
         /**
          * This is called by [create()]{@link Model.create} to initialize a model instance.
@@ -263,10 +253,7 @@ declare module "@croquet/croquet" {
          * @param options - there are no system-defined options, you're free to define your own
          * @public
          */
-        init(
-            _options: Record<string, unknown>,
-            persistentData?: Record<string, unknown>,
-        ): void;
+        init(_options: any, persistentData?: any): void;
 
         /**
          * Unsubscribes all [subscriptions]{@link Model#subscribe} this model has,
@@ -460,11 +447,7 @@ declare module "@croquet/croquet" {
          * @returns {this}
          * @public
          */
-        future<T extends unknown[]>(
-            tOffset?: number,
-            method?: FutureHandler<T>,
-            ...args: T
-        ): this;
+        future<T extends any[]>(tOffset?:number, method?: FutureHandler<T>, ...args: T): this;
 
         /**
          * **Cancel a previously scheduled future message**
@@ -483,8 +466,8 @@ declare module "@croquet/croquet" {
          * @returns {Boolean} true if the message was found and canceled, false otherwise
          * @since 1.1.0-16
          * @public
-         */
-        cancelFuture<T extends unknown[]>(method: FutureHandler<T>): boolean;
+        */
+        cancelFuture<T extends any[]>(method: FutureHandler<T>): boolean;
 
         /** **Generate a synchronized pseudo-random number**
          *
@@ -494,7 +477,7 @@ declare module "@croquet/croquet" {
          *
          * Since the model computation is synchronized for every user on their device, the sequence of random numbers
          * generated must also be exactly the same for everyone. This method provides access to such a random number generator.
-         */
+        */
         random(): number;
 
         /** **The model's current time**
@@ -538,6 +521,7 @@ declare module "@croquet/croquet" {
          * ```
          */
         wellKnownModel<M extends Model>(name: string): Model | undefined;
+
 
         /** Look up a model in the current session given its `id`.
          *
@@ -599,15 +583,10 @@ declare module "@croquet/croquet" {
          * @public
          * @since 2.0
          */
-        createQFunc<T extends (...args: readonly unknown[]) => unknown>(
-            env: QFuncEnv,
-            func: T | string,
-        ): T;
-        createQFunc<T extends (...args: readonly unknown[]) => unknown>(
-            func: T | string,
-        ): T;
+        createQFunc<T extends Function>(env: QFuncEnv, func: T|string): T;
+        createQFunc<T extends Function>(func: T|string): T;
 
-        persistSession(func: () => object): void;
+        persistSession(func: () => any): void;
 
         /** **Identifies the shared session of all users**
          *
@@ -651,8 +630,8 @@ declare module "@croquet/croquet" {
             name: string;
             lat: number;
             lng: number;
-        };
-    };
+        }
+    }
 
     /** payload of view-join and view-exit if viewData was passed in Session.join */
     export type ViewInfo<T> = {
@@ -795,7 +774,7 @@ declare module "@croquet/croquet" {
             eventSpec:
                 | string
                 | { event: string; handling: "queued" | "oncePerFrame" | "immediate" },
-            callback: (e: unknown) => void,
+            callback: (e: any) => void,
         ): void;
 
         /**
@@ -867,7 +846,7 @@ declare module "@croquet/croquet" {
          * The unit is milliseconds (1/1000 second) but the value can be fractional, it is a floating-point value.
          *
          * Returns: the model's time in milliseconds since the first user created the session.
-         */
+        */
         now(): number;
 
         /** **The latest timestamp received from reflector**
@@ -885,7 +864,7 @@ declare module "@croquet/croquet" {
          * ```
          * const backlog = this.externalNow() - this.now();
          * ```
-         */
+        */
         externalNow(): number;
 
         /**
@@ -910,7 +889,7 @@ declare module "@croquet/croquet" {
          * you will have to call those methods from the root view's `update()`.
          *
          * The time received is related to the local real-world time. If you need to access the model's time, use [this.now()]{@link View#now}.
-         */
+        */
         update(time: number): void;
 
         /** Access a model that was registered previously using beWellKnownAs().
@@ -930,10 +909,11 @@ declare module "@croquet/croquet" {
          * Note: The view instance may be taken down and reconstructed during the lifetime of a session. the `view` property of the session may differ from `this`, when you store the view instance in our data structure outside of Croquet and access it sometime later.
          * @public
          */
+
         get session(): CroquetSession<View>;
 
         /** make module exports accessible via any subclass */
-        static Croquet: typeof import("@croquet/croquet");
+        static Croquet: Croquet;
     }
 
     export type CroquetSession<V extends View> = {
@@ -970,7 +950,7 @@ declare module "@croquet/croquet" {
         | "write"
         | "offline";
 
-    type ClassOf<M> = new (...args: readonly unknown[]) => M;
+    type ClassOf<M> = new (...args: any[]) => M;
 
     export type CroquetSessionParameters<M extends Model, V extends View, T> = {
         apiKey?: string;
@@ -1000,7 +980,7 @@ declare module "@croquet/croquet" {
         ): Promise<CroquetSession<V>>;
     }
 
-    export const Constants: Record<string, unknown>;
+    export var Constants: Record<string, any>;
 
     export const VERSION: string;
 
@@ -1062,7 +1042,14 @@ declare module "@croquet/croquet" {
         randomPassword: (len?: number) => string;
     }
 
-    export const App: IApp;
+    /**
+     * The App API is under construction.
+     *
+     * @public
+     */
+
+    export var App:IApp;
+
 
     interface DataHandle {
         store(
@@ -1074,7 +1061,14 @@ declare module "@croquet/croquet" {
         hash(data: unknown, output?: string): string;
     }
 
-    export const Data: DataHandle;
+    /**
+     * The Data API is under construction.
+     *
+     * @public
+     */
+
+    export var Data: DataHandle;
+
 
     type Croquet = {
         Model: typeof Model;

--- a/packages/reflector/README.md
+++ b/packages/reflector/README.md
@@ -59,14 +59,6 @@ The easiest way to deploy a complete Croquet environment is [Croquet-in-a-Box](.
 
 This is the recommended approach for most production deployments.
 
-### Custom Deployment
-For custom deployments, you'll need to handle:
-- WebSocket server hosting
-- SSL/TLS termination
-- Load balancing (if needed)
-- File server for snapshots
-- Monitoring and logging
-
 ## 📊 Logging & Monitoring
 
 ### Log Levels
@@ -174,19 +166,3 @@ const impls = [
 - **WebSocket errors**: Check firewall and proxy settings
 - **Memory leaks**: Monitor for growing message histories
 - **Performance degradation**: Watch for excessive message rates
-
-## 🤝 Contributing
-
-When contributing to the reflector:
-1. Follow existing logging patterns
-2. Add appropriate `NOTICE()` calls for significant events
-3. Include relevant metadata in log entries
-4. Test on both x64 and ARM architectures
-5. Verify production logging compatibility
-
----
-
-## 📄 License
-
-Licensed under the same terms as the main Croquet project.
-

--- a/server/croquet-in-a-box/README.md
+++ b/server/croquet-in-a-box/README.md
@@ -1,30 +1,204 @@
 # Croquet in a Box
 
-All-in-one package of reflector, file server, and web server.
+**Complete local Croquet development environment in a single Docker container.** Perfect for development, testing, and learning without requiring API keys or external services.
 
-Implemented via Docker Compose to be easily installed on various machines.
+Croquet-in-a-Box combines all essential services into one easy-to-deploy package:
+- 🔄 **Reflector server** - Keeps clients synchronized
+- 🌐 **Web server** - Serves your applications  
+- 📁 **File server** - Handles data storage and sharing
 
-## Prerequisites
+*Implemented with Docker Compose for seamless deployment across different environments.*
 
-Docker, Bash
+## 🚀 Quick Start
 
-## Run it
+### Prerequisites
+- **Docker** - [Install Docker](https://docs.docker.com/get-docker/)
+- **Bash** - Available on Linux, macOS, and Windows (WSL/Git Bash)
 
-    ./croquet-in-a-box.sh
+### Launch the Environment
 
-then go to http://localhost:8888/ and try the examples.
+```bash
+./croquet-in-a-box.sh
+```
 
-The apps on that page use a `box` parameter in `Session.join()` instead of an API key. They don't connect to the public reflectors but to this box. In there, `box=/` is equivalent to `box=http://localhost:8888/` which in turn is equivalent to  `reflector=ws://localhost:8888/reflector&files=http://localhost:8888/files` (Croquet clients before 2.0.0 needed the latter, since then the `box` shortcut works).
+Then open your browser to [http://localhost:8888/](http://localhost:8888/) and explore the included examples!
 
-Substitute your external IP address for `localhost` to be able to join from other devices.
+## 🎯 How It Works
 
-You can override the default port number and location of the webroot and files:
+### Service Architecture
+The Docker Compose configuration runs two optimized containers:
 
-    ./croquet-in-a-box.sh <port> <webroot dir> <files dir>
+1. **Reflector Container**: Dedicated Croquet reflector server
+2. **Nginx Container**: Combined web server, file server, and reverse proxy
 
-## What it does
+### URL Structure
+- **Web Server**: [localhost:8888](http://localhost:8888/) - Serves applications from `./webroot`
+- **File Server**: [localhost:8888/files](http://localhost:8888/files/) - Handles uploads/downloads to `./files`  
+- **Reflector**: [localhost:8888/reflector](http://localhost:8888/reflector) - WebSocket endpoint for Croquet clients
 
-As defined in the `docker-compose.yml` file it runs two docker images – one for the reflector, and one nginx image for the webserver/fileserver and reflector proxy.
+### Session Configuration
+Applications use the `box` parameter instead of traditional API keys:
 
-On [localhost:8888](http://localhost:8888/) is the web server (serving `./webroot`),
-[localhost:8888/files](http://localhost:8888/files/) is the file server (upload and download to `./files`), and [localhost:8888/reflector](http://localhost:8888/reflector) is the reflector.
+```javascript
+// Instead of apiKey, use box parameter
+Croquet.Session.join({
+    box: "/",  // Equivalent to box: "http://localhost:8888/"
+    // ... other parameters
+});
+```
+
+**URL Equivalencies:**
+- `box: "/"` 
+- `box: "http://localhost:8888/"`
+- `reflector: "ws://localhost:8888/reflector"` + `files: "http://localhost:8888/files"`
+
+*Note: Croquet 2.0+ supports the convenient `box` shortcut. Earlier versions require explicit `reflector` and `files` parameters.*
+
+## ⚙️ Configuration Options
+
+### Custom Ports and Directories
+
+```bash
+./croquet-in-a-box.sh <port> <webroot-dir> <files-dir>
+```
+
+**Examples:**
+```bash
+# Use port 3000 instead of 8888
+./croquet-in-a-box.sh 3000
+
+# Custom directories
+./croquet-in-a-box.sh 8888 /path/to/my/apps /path/to/my/files
+
+# Both custom port and directories
+./croquet-in-a-box.sh 3000 ./my-webroot ./my-files
+```
+
+### Multi-Device Access
+
+Replace `localhost` with your machine's IP address to enable access from other devices:
+
+```bash
+# Find your IP address (example: 192.168.1.100)
+# Then access from any device on the same network:
+http://192.168.1.100:8888/
+```
+
+## 🌐 Development Workflow
+
+### Local Development
+1. **Start the environment**: `./croquet-in-a-box.sh`
+2. **Develop your app**: Place files in `./webroot/`
+3. **Test immediately**: Visit `http://localhost:8888/your-app/`
+4. **Multi-user testing**: Open multiple browser tabs or devices
+
+### File Management
+- **Static assets**: Place in `./webroot/` (served by web server)
+- **User uploads**: Automatically handled in `./files/` (managed by file server)
+- **Persistence**: Both directories persist between container restarts
+
+### Debugging
+Enable debug mode by adding URL parameters:
+```
+http://localhost:8888/your-app/?debug=session,messages
+```
+
+## 🔧 Container Management
+
+### Starting and Stopping
+```bash
+# Start (via script - recommended)
+./croquet-in-a-box.sh
+
+# Stop services
+docker-compose down
+
+# Stop and remove volumes
+docker-compose down -v
+```
+
+### Viewing Logs
+```bash
+# All services
+docker-compose logs -f
+
+# Specific service
+docker-compose logs -f reflector
+docker-compose logs -f nginx
+```
+
+### Health Checks
+```bash
+# Check running services
+docker-compose ps
+
+# Test endpoints
+curl http://localhost:8888/          # Web server
+curl http://localhost:8888/files/    # File server
+```
+
+## 📋 Use Cases
+
+### Development & Testing
+- ✅ **Offline development** - No internet connection required
+- ✅ **Rapid iteration** - No deployment steps
+- ✅ **Multi-device testing** - Easy local network sharing
+- ✅ **No API key management** - Simplified configuration
+
+### Learning & Demos
+- ✅ **Workshop environments** - Quick setup for groups
+- ✅ **Educational settings** - No external dependencies
+- ✅ **Proof of concepts** - Immediate demonstration capability
+
+### Production Staging
+- ✅ **Integration testing** - Full Croquet environment simulation
+- ✅ **Performance testing** - Isolated environment for load testing
+- ✅ **Deployment validation** - Test before production release
+
+## 🔒 Security Considerations
+
+### Network Exposure
+- **Default**: Only accessible from localhost
+- **LAN Access**: Requires manual IP configuration
+- **Internet Access**: Not recommended without additional security measures
+
+### Production Usage
+Croquet-in-a-Box is designed for development and testing. For production:
+- Use [Multisynq's hosted service](https://multisynq.io) (recommended)
+- Deploy individual components with proper security hardening
+- Implement SSL/TLS termination
+- Configure proper authentication and authorization
+
+## 🐛 Troubleshooting
+
+### Common Issues
+
+**Port Already in Use:**
+```bash
+# Check what's using port 8888
+lsof -i :8888
+
+# Use different port
+./croquet-in-a-box.sh 3000
+```
+
+**Permission Denied:**
+```bash
+# Make script executable
+chmod +x croquet-in-a-box.sh
+```
+
+**Docker Not Running:**
+```bash
+# Start Docker service
+sudo systemctl start docker  # Linux
+# Or start Docker Desktop (Windows/macOS)
+```
+
+**Container Build Failures:**
+```bash
+# Clean rebuild
+docker-compose down -v
+docker-compose build --no-cache
+./croquet-in-a-box.sh
+```


### PR DESCRIPTION
This was meant to be a simple fix: autoSession(name: string) -> autoSession(name?: string) as well as a Readme typo fix:
"Some of the examples in `apps/` require to build a local version" -> require building 
"place holder" -> placeholder
But claude + biomejs linter got a bit heavy handed. 

I think the overall flow and additions are a slight improvement, however, so have left them in for review. 