### PR TITLE
add type parameter for view-side subscribe method

### DIFF
--- a/packages/croquet/types.d.ts
+++ b/packages/croquet/types.d.ts
@@ -769,12 +769,12 @@ declare module "@croquet/croquet" {
          * @return {this}
          * @public
          */
-        subscribe(
+        subscribe<T>(
             scope: string,
             eventSpec:
                 | string
                 | { event: string; handling: "queued" | "oncePerFrame" | "immediate" },
-            callback: (e: any) => void,
+            callback: SubscriptionHandler<T>,
         ): void;
 
         /**


### PR DESCRIPTION
For TypeScript based project it is good to specify the type of the object that goes from publish to subscribe. However, types.d.ts just misses a type annotation to be able to do so. This PR fixes the problem.